### PR TITLE
fix: use ico image instead of svg for favicon

### DIFF
--- a/src/static/template.liquid
+++ b/src/static/template.liquid
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf8">
     <meta name="theme-color" content="#ffffff">
-    <link rel="icon" href="favicon.svg">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <meta name="viewport" content="width=device-width,initial-scale=1.0"  />
     <style>


### PR DESCRIPTION
Hello!

I noticed that you accidentally used `favicon.svg` instead of `favicon.ico` resulting in the page icon not loading, just fixed the typo : )