### PR TITLE
Dockerfile: specify exposed port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,5 @@ FROM scratch
 # Copy binary
 COPY --from=build /cup/target/release/cup /cup
 
+EXPOSE 8000
 ENTRYPOINT ["/cup"]


### PR DESCRIPTION
Adheres to the convention and simplifies life of discovering reverse proxies like traefik.