### PR TITLE
Fix refresh button when using custom base url

### DIFF
--- a/web/src/components/RefreshButton.tsx
+++ b/web/src/components/RefreshButton.tsx
@@ -14,7 +14,7 @@ export default function RefreshButton() {
     request.open(
       "GET",
       process.env.NODE_ENV === "production"
-        ? "/api/v3/refresh"
+        ? "./api/v3/refresh"
         : `http://${window.location.hostname}:8000/api/v3/refresh`,
     );
     request.send();


### PR DESCRIPTION
Support for a custom base URL was added in this commit - https://github.com/sergi0g/cup/commit/b37b7ed060d6a30a0b80dc127309fb3cfde7a919. However, the refresh button was still using an absolute URL, which caused it to ignore the custom base URL and result in a 404 error when pressed.

![image](https://github.com/user-attachments/assets/e7f54e9d-4a96-48e0-9416-7d91e274ada0)

This MR fixes that issue