### PR TITLE
feat: add ability to pin major, minor or patch version

### DIFF
--- a/cup.schema.json
+++ b/cup.schema.json
@@ -14,6 +14,16 @@
             "type": "boolean",
             "description": "Whether or not to enable agent mode. When agent mode is enabled, the server only exposes the API and the web interface is unavailable."
         },
+        "ignore_update_type": {
+            "type": "string",
+            "description": "The types of updates to ignore. Ignoring an update type also implies ignoring all update types less specific than it. For example, ignoring patch updates also implies ignoring major and minor updates.",
+            "enum": [
+                "none",
+                "major",
+                "minor",
+                "patch"
+            ]
+        },
         "images": {
             "type": "object",
             "description": "Configuration options for specific images",
@@ -59,8 +69,8 @@
             }
         },
         "socket": {
-            "description": "The path to the unix socket you would like Cup to use for communication with the Docker daemon. Useful if you're trying to use Cup with Podman.",
             "type": "string",
+            "description": "The path to the unix socket you would like Cup to use for communication with the Docker daemon. Useful if you're trying to use Cup with Podman.",
             "minLength": 1
         },
         "servers": {
@@ -73,8 +83,8 @@
             "minProperties": 1
         },
         "theme": {
-            "description": "The theme used by the web UI",
             "type": "string",
+            "description": "The theme used by the web UI",
             "enum": [
                 "default",
                 "blue"

--- a/docs/src/content/docs/configuration/ignore-update-type.mdx
+++ b/docs/src/content/docs/configuration/ignore-update-type.mdx
@@ -1,0 +1,23 @@
+import { Callout } from "nextra/components";
+
+# Ignored update types
+
+To ignore certain update types, you can modify your config like this:
+
+```jsonc
+{
+  "ignore_update_type": "minor"
+}
+```
+
+Available options are:
+
+- `none`: Do not ignore any update types (default).
+- `major`: Ignore major updates.
+- `minor`: Ignore major and minor updates.
+- `patch`: Ignore major, minor and patch updates.
+
+<Callout emoji="⚠️">
+  Ignoring an update type also implies ignoring all update types less specific than it.
+  For example, ignoring patch updates also implies ignoring major and minor updates.
+</Callout>

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,16 +6,30 @@ use serde::Deserialize;
 use crate::error;
 
 #[derive(Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Theme {
-    #[serde(rename = "default")]
     Default,
-    #[serde(rename = "blue")]
     Blue,
 }
 
 impl Default for Theme {
     fn default() -> Self {
         Self::Default
+    }
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateType {
+    None,
+    Major,
+    Minor,
+    Patch,
+}
+
+impl Default for UpdateType {
+    fn default() -> Self {
+        Self::None
     }
 }
 
@@ -40,6 +54,7 @@ pub struct ImageConfig {
 pub struct Config {
     version: u8,
     pub agent: bool,
+    pub ignore_update_type: UpdateType,
     pub images: ImageConfig,
     pub refresh_interval: Option<String>,
     pub registries: FxHashMap<String, RegistryConfig>,
@@ -53,6 +68,7 @@ impl Config {
         Self {
             version: 3,
             agent: false,
+            ignore_update_type: UpdateType::default(),
             images: ImageConfig::default(),
             refresh_interval: None,
             registries: FxHashMap::default(),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -3,6 +3,7 @@ use std::time::SystemTime;
 use itertools::Itertools;
 
 use crate::{
+    config::UpdateType,
     error,
     http::Client,
     structs::{
@@ -150,6 +151,7 @@ pub async fn get_latest_tag(
             &headers,
             base,
             &image.version_info.as_ref().unwrap().format_str,
+            ctx,
             client,
         )
         .await
@@ -214,6 +216,7 @@ pub async fn get_extra_tags(
     headers: &[(&str, Option<&str>)],
     base: &Version,
     format_str: &str,
+    ctx: &Context,
     client: &Client,
 ) -> Result<(Vec<Version>, Option<String>), String> {
     let response = client.get(url, &headers, false).await;
@@ -237,7 +240,18 @@ pub async fn get_extra_tags(
                     }
                     _ => false,
                 })
-                .map(|(tag, _)| tag)
+                .filter_map(|(tag, _)| match ctx.config.ignore_update_type {
+                    UpdateType::None => Some(tag),
+                    UpdateType::Major => Some(tag).filter(|tag| base.major == tag.major),
+                    UpdateType::Minor => {
+                        Some(tag).filter(|tag| base.major == tag.major && base.minor == tag.minor)
+                    }
+                    UpdateType::Patch => Some(tag).filter(|tag| {
+                        base.major == tag.major
+                            && base.minor == tag.minor
+                            && base.patch == tag.patch
+                    }),
+                })
                 .dedup()
                 .collect();
             Ok((result, next_url))


### PR DESCRIPTION
As referenced in https://github.com/sergi0g/cup/issues/75#issuecomment-2774070433, I have implemented version pinning for updates. Some examples:

**No pinning (current behaviour):**

 ```
╭─────────────────────────────────────────────────────────┬──────────────────────────────┬─────────╮
│Reference                                                │Status                        │Time (ms)│
├─────────────────────────────────────────────────────────┼──────────────────────────────┼─────────┤
│docker.io/library/mariadb:10.11                          │Major update (10.11 → 11.7)   │600      │
│docker.io/library/elasticsearch:8.13.0                   │Minor update (8.13.0 → 8.17.4)│732      │
│docker.io/library/memcached:1.6.18                       │Patch update (1.6.18 → 1.6.38)│268      │
│ghcr.io/sergi0g/cup:latest                               │Update available              │291      │
│docker.io/gitea/gitea:latest                             │Up to date                    │752      │
╰─────────────────────────────────────────────────────────┴──────────────────────────────┴─────────╯
```

**Pin major updates:**

 ```
╭─────────────────────────────────────────────────────────┬──────────────────────────────┬─────────╮
│Reference                                                │Status                        │Time (ms)│
├─────────────────────────────────────────────────────────┼──────────────────────────────┼─────────┤
│docker.io/library/elasticsearch:8.13.0                   │Minor update (8.13.0 → 8.17.4)│732      │
│docker.io/library/memcached:1.6.18                       │Patch update (1.6.18 → 1.6.38)│268      │
│ghcr.io/sergi0g/cup:latest                               │Update available              │291      │
│docker.io/gitea/gitea:latest                             │Up to date                    │752      │
╰─────────────────────────────────────────────────────────┴──────────────────────────────┴─────────╯
```

**Pin minor updates:**

 ```
╭─────────────────────────────────────────────────────────┬──────────────────────────────┬─────────╮
│Reference                                                │Status                        │Time (ms)│
├─────────────────────────────────────────────────────────┼──────────────────────────────┼─────────┤
│docker.io/library/elasticsearch:8.13.0                   │Patch update (8.13.0 → 8.13.4)│730      │
│docker.io/library/memcached:1.6.18                       │Patch update (1.6.18 → 1.6.38)│268      │
│ghcr.io/sergi0g/cup:latest                               │Update available              │291      │
│docker.io/gitea/gitea:latest                             │Up to date                    │752      │
╰─────────────────────────────────────────────────────────┴──────────────────────────────┴─────────╯
```

**Pin patch updates:**

 ```
╭─────────────────────────────────────────────────────────┬────────────────┬─────────╮
│Reference                                                │Status          │Time (ms)│
├─────────────────────────────────────────────────────────┼────────────────┼─────────┤
│ghcr.io/sergi0g/cup:latest                               │Update available│299      │
│docker.io/gitea/gitea:latest                             │Up to date      │726      │
╰─────────────────────────────────────────────────────────┴────────────────┴─────────╯
```

I am open to a different configuration name, as I'm not sure that `pin` is necessarily the most descriptive. Please also let me know if you prefer an alternative implementation; this was just what fit my use-case the best.