### PR TITLE
Allow to set none as socket value to disable Docker/Podman query

### DIFF
--- a/cup.schema.json
+++ b/cup.schema.json
@@ -70,7 +70,7 @@
         },
         "socket": {
             "type": "string",
-            "description": "The path to the unix socket you would like Cup to use for communication with the Docker daemon. Useful if you're trying to use Cup with Podman.",
+            "description": "The path to the unix socket you would like Cup to use for communication with the Docker daemon. Useful if you're trying to use Cup with Podman. To disable use \"none\" as value.",
             "minLength": 1
         },
         "servers": {

--- a/docs/src/content/docs/configuration/index.mdx
+++ b/docs/src/content/docs/configuration/index.mdx
@@ -23,13 +23,15 @@ For example, if using Podman, you might do
 $ cup -s /run/user/1000/podman/podman.sock check
 ```
 
-This option is also available in the configuration file and it's best to put it there.
+This option is also available in the configuration file and it's best to put it there. If both are defined the CLI `-s` option takes precedence.
 
 <Cards.Card
   icon={<IconPlug />}
   title="Custom Docker socket"
   href="/docs/configuration/socket"
 />
+
+To disable Docker/Podman socket use "none" as value.
 
 ## Configuration file
 

--- a/docs/src/content/docs/configuration/socket.mdx
+++ b/docs/src/content/docs/configuration/socket.mdx
@@ -17,3 +17,12 @@ You can also specify a TCP socket if you're using a remote Docker host or a [pro
   // Other options
 }
 ```
+
+Or use the "none" value to disable any Docker/Podman query:
+
+```jsonc
+{
+  "socket": "none"
+  // Other options
+}
+```

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -41,6 +41,9 @@ pub async fn get_images_from_docker_daemon(
     ctx: &Context,
     references: &Option<Vec<String>>,
 ) -> Vec<Image> {
+    if ctx.config.socket.as_deref() == Some("none") {
+        return vec![];
+    }
     let client: Docker = create_docker_client(ctx.config.socket.as_deref());
     let mut swarm_images = match client.list_services::<String>(None).await {
         Ok(services) => services
@@ -96,6 +99,10 @@ pub async fn get_images_from_docker_daemon(
 }
 
 pub async fn get_in_use_images(ctx: &Context) -> Vec<String> {
+    if ctx.config.socket.as_deref() == Some("none") {
+        return vec![];
+    }
+
     let client: Docker = create_docker_client(ctx.config.socket.as_deref());
 
     let containers = match client


### PR DESCRIPTION
PR to address the [[FR] Ability to switch off docker socket requirement #109](https://github.com/sergi0g/cup/issues/109). As I'm not a Rust dev (this is my first Rust code ever :P) I took the most direct approach.

Tested with CLI -s and "socket" config options. Tested that web server works correctly and the data is retrieved from remote Cup instances.

`cargo clippy` has one suggestion but in existing, not changed code so leaving this for another PR.
`cargo fmt` formats two other files which are not in scope of this PR so I'm leaving those unchanged too.