### PR TITLE
fix(css): use `inline-flex` style instead of `block` on bigger screens

### DIFF
--- a/web/src/components/Badge.tsx
+++ b/web/src/components/Badge.tsx
@@ -4,7 +4,7 @@ import { theme } from "../theme";
 export default function Badge({ from, to }: { from: string; to: string }) {
   return (
     <span
-      className={`hidden sm:block inline-flex items-center rounded-full bg-${theme}-50 px-2 py-1 text-xs font-medium text-${theme}-700 ring-1 ring-inset ring-${theme}-700/10 dark:bg-${theme}-400/10 dark:text-${theme}-400 dark:ring-${theme}-400/30 break-keep`}
+      className={`hidden sm:inline-flex items-center rounded-full bg-${theme}-50 px-2 py-1 text-xs font-medium text-${theme}-700 ring-1 ring-inset ring-${theme}-700/10 dark:bg-${theme}-400/10 dark:text-${theme}-400 dark:ring-${theme}-400/30 break-keep`}
     >
       {from}
       <ArrowRight className="size-3" />


### PR DESCRIPTION
## Description

This PR updates the style of the `Badge` component to use `inline-flex` instead of `block` on bigger screens.

- Fixes: <https://github.com/sergi0g/cup/issues/151>

## UI Changes

**Before:**
<img width="728" height="396" alt="image" src="https://github.com/user-attachments/assets/89ce0370-5a6b-4d86-b6b5-2e16d157c58f" />

**After:**

<img width="726" height="338" alt="image" src="https://github.com/user-attachments/assets/acabcac4-d6a8-4ba9-a3a2-4bc16bb8034c" />

<img width="405" height="411" alt="image" src="https://github.com/user-attachments/assets/7d2fbe2f-cbc3-4375-9bf1-c22b04df4f55" />
