### PR TITLE
Non-blocking background refresh and faster tag pagination

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -14,64 +14,87 @@ use crate::{
     Context,
 };
 
+/// Fetches image data from a single remote Cup instance
+pub async fn get_single_server_updates(
+    name: &str,
+    url: &str,
+    refresh: bool,
+    ctx: &Context,
+) -> Vec<Update> {
+    let client = Client::new(ctx);
+    let base_url = if url.starts_with("http://") || url.starts_with("https://") {
+        format!("{}/api/v3/", url.trim_end_matches('/'))
+    } else {
+        format!("https://{}/api/v3/", url.trim_end_matches('/'))
+    };
+    let json_url = base_url.clone() + "json";
+    if refresh {
+        let refresh_url = base_url + "refresh";
+        match client.get(&refresh_url, &[], false).await {
+            Ok(response) => {
+                if response.status() != 200 {
+                    ctx.logger.warn(format!("GET {}: Failed to refresh server. Server returned invalid response code: {}", refresh_url, response.status()));
+                    return Vec::new();
+                }
+            }
+            Err(e) => {
+                ctx.logger.warn(format!(
+                    "GET {}: Failed to refresh server. {}",
+                    refresh_url, e
+                ));
+                return Vec::new();
+            }
+        }
+    }
+    match client.get(&json_url, &[], false).await {
+        Ok(response) => {
+            if response.status() != 200 {
+                ctx.logger.warn(format!("GET {}: Failed to fetch updates from server. Server returned invalid response code: {}", json_url, response.status()));
+                return Vec::new();
+            }
+            let json = parse_json(&get_response_body(response).await);
+            ctx.logger
+                .debug(format!("JSON response for {}: {}", name, json));
+            if let Some(updates) = json["images"].as_array() {
+                let mut server_updates: Vec<Update> = updates
+                    .iter()
+                    .filter_map(|img| serde_json::from_value(img.clone()).ok())
+                    .collect();
+                // Add server origin to each image
+                for update in &mut server_updates {
+                    update.server = Some(name.to_string());
+                    update.status = update.get_status();
+                }
+                ctx.logger
+                    .debug(format!("Updates for {}: {:#?}", name, server_updates));
+                return server_updates;
+            }
+
+            Vec::new()
+        }
+        Err(e) => {
+            ctx.logger.warn(format!(
+                "GET {}: Failed to fetch updates from server. {}",
+                json_url, e
+            ));
+            Vec::new()
+        }
+    }
+}
+
 /// Fetches image data from other Cup instances
-async fn get_remote_updates(ctx: &Context, client: &Client, refresh: bool) -> Vec<Update> {
+async fn get_remote_updates(ctx: &Context, refresh: bool) -> Vec<Update> {
     let mut remote_images = Vec::new();
 
-    let handles: Vec<_> = ctx.config.servers
+    let handles: Vec<_> = ctx
+        .config
+        .servers
         .iter()
-        .map(|(name, url)| async move {
-            let base_url = if url.starts_with("http://") || url.starts_with("https://") {
-                format!("{}/api/v3/", url.trim_end_matches('/'))
-            } else {
-                format!("https://{}/api/v3/", url.trim_end_matches('/'))
-            };
-            let json_url = base_url.clone() + "json";
-            if refresh {
-                let refresh_url = base_url + "refresh";
-                match client.get(&refresh_url, &[], false).await {
-                    Ok(response) => {
-                        if response.status() != 200 {
-                            ctx.logger.warn(format!("GET {}: Failed to refresh server. Server returned invalid response code: {}", refresh_url, response.status()));
-                            return Vec::new();
-                        }
-                    },
-                    Err(e) => {
-                        ctx.logger.warn(format!("GET {}: Failed to refresh server. {}", refresh_url, e));
-                        return Vec::new();
-                    },
-                }
-
-            }
-            match client.get(&json_url, &[], false).await {
-                Ok(response) => {
-                    if response.status() != 200 {
-                        ctx.logger.warn(format!("GET {}: Failed to fetch updates from server. Server returned invalid response code: {}", json_url, response.status()));
-                        return Vec::new();
-                    }
-                    let json = parse_json(&get_response_body(response).await);
-                    ctx.logger.debug(format!("JSON response for {}: {}", name, json));
-                    if let Some(updates) = json["images"].as_array() {
-                        let mut server_updates: Vec<Update> = updates
-                            .iter()
-                            .filter_map(|img| serde_json::from_value(img.clone()).ok())
-                            .collect();
-                        // Add server origin to each image
-                        for update in &mut server_updates {
-                            update.server = Some(name.clone());
-                            update.status = update.get_status();
-                        }
-                        ctx.logger.debug(format!("Updates for {}: {:#?}", name, server_updates));
-                        return server_updates;
-                    }
-
-                    Vec::new()
-                }
-                Err(e) => {
-                    ctx.logger.warn(format!("GET {}: Failed to fetch updates from server. {}", json_url, e));
-                    Vec::new()
-                },
-            }
+        .map(|(name, url)| {
+            let name = name.clone();
+            let url = url.clone();
+            let ctx = ctx.clone();
+            async move { get_single_server_updates(&name, &url, refresh, &ctx).await }
         })
         .collect();
 
@@ -97,12 +120,8 @@ fn get_excluded_tags(image: &Image, ctx: &Context) -> Vec<String> {
         .collect()
 }
 
-/// Returns a list of updates for all images passed in.
-pub async fn get_updates(
-    references: &Option<Vec<String>>, // If a user requested _specific_ references to be checked, this will have a value
-    refresh: bool,
-    ctx: &Context,
-) -> Vec<Update> {
+/// Returns a list of updates for local images only (no remote servers).
+pub async fn get_local_updates(references: &Option<Vec<String>>, ctx: &Context) -> Vec<Update> {
     let client = Client::new(ctx);
 
     // Merge references argument with references from config
@@ -141,14 +160,6 @@ pub async fn get_updates(
         images.extend(extra);
     }
 
-    // Get remote images from other servers
-    let remote_updates = if !ctx.config.servers.is_empty() {
-        ctx.logger.debug("Fetching updates from remote servers");
-        get_remote_updates(ctx, &client, refresh).await
-    } else {
-        Vec::new()
-    };
-
     ctx.logger.debug(format!(
         "Checking {:?}",
         images.iter().map(|image| &image.reference).collect_vec()
@@ -164,10 +175,6 @@ pub async fn get_updates(
             None => true,
         })
         .collect::<Vec<&String>>();
-
-    // Create request client. All network requests share the same client for better performance.
-    // This client is also configured to retry a failed request up to 3 times with exponential backoff in between.
-    let client = Client::new(ctx);
 
     // Create a map of images indexed by registry. This solution seems quite inefficient, since each iteration causes a key to be looked up. I can't find anything better at the moment.
     let mut image_map: FxHashMap<&String, Vec<&Image>> = FxHashMap::default();
@@ -226,7 +233,23 @@ pub async fn get_updates(
     }
     // Await all the futures
     let images = join_all(handles).await;
-    let mut updates: Vec<Update> = images.iter().map(|image| image.to_update()).collect();
-    updates.extend_from_slice(&remote_updates);
+    images.iter().map(|image| image.to_update()).collect()
+}
+
+/// Returns a list of updates for all images passed in.
+pub async fn get_updates(
+    references: &Option<Vec<String>>,
+    refresh: bool,
+    ctx: &Context,
+) -> Vec<Update> {
+    let mut updates = get_local_updates(references, ctx).await;
+
+    // Get remote images from other servers
+    if !ctx.config.servers.is_empty() {
+        ctx.logger.debug("Fetching updates from remote servers");
+        let remote_updates = get_remote_updates(ctx, refresh).await;
+        updates.extend(remote_updates);
+    }
+
     updates
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -129,7 +129,7 @@ pub async fn get_latest_tag(
     let start = now();
     let protocol = get_protocol(&image.parts.registry, &ctx.config.registries);
     let url = format!(
-        "{}://{}/v2/{}/tags/list",
+        "{}://{}/v2/{}/tags/list?n=10000",
         protocol, &image.parts.registry, &image.parts.repository,
     );
     let authorization = to_bearer_string(&token);

--- a/src/server.rs
+++ b/src/server.rs
@@ -51,9 +51,13 @@ const SORT_ORDER: [&str; 8] = [
 
 pub async fn serve(port: &u16, ctx: &Context) -> std::io::Result<()> {
     ctx.logger.info("Starting server, please wait...");
-    let data = ServerData::new(ctx).await;
-    let scheduler = JobScheduler::new().await.unwrap();
+    let data = ServerData::new(ctx);
     let data = Arc::new(Mutex::new(data));
+
+    // Blocking initial refresh — populates data before we start serving
+    background_refresh(data.clone()).await;
+
+    let scheduler = JobScheduler::new().await.unwrap();
     let data_copy = data.clone();
     let tz = env::var("TZ")
         .map(|tz| tz.parse().unwrap_or(Tz::UTC))
@@ -61,16 +65,12 @@ pub async fn serve(port: &u16, ctx: &Context) -> std::io::Result<()> {
     if let Some(interval) = &ctx.config.refresh_interval {
         scheduler
             .add(
-                match Job::new_async_tz(
-                    interval,
-                    tz,
-                    move |_uuid, _lock| {
-                        let data_copy = data_copy.clone();
-                        Box::pin(async move {
-                            data_copy.lock().await.refresh().await;
-                        })
-                    },
-                ) {
+                match Job::new_async_tz(interval, tz, move |_uuid, _lock| {
+                    let data_copy = data_copy.clone();
+                    Box::pin(async move {
+                        background_refresh(data_copy).await;
+                    })
+                }) {
                     Ok(job) => job,
                     Err(e) => match e {
                         tokio_cron_scheduler::JobSchedulerError::ParseSchedule => error!(
@@ -167,7 +167,10 @@ async fn api_full(data: StateRef<'_, Arc<Mutex<ServerData>>>) -> WebResponse {
 }
 
 async fn refresh(data: StateRef<'_, Arc<Mutex<ServerData>>>) -> WebResponse {
-    data.lock().await.refresh().await;
+    let data = data.clone();
+    tokio::spawn(async move {
+        background_refresh(data).await;
+    });
     WebResponse::new(ResponseBody::from("OK"))
 }
 
@@ -181,86 +184,111 @@ struct ServerData {
 }
 
 impl ServerData {
-    async fn new(ctx: &Context) -> Self {
-        let mut s = Self {
-            ctx: ctx.clone(),
-            template: String::new(),
-            simple_json: Value::Null,
-            full_json: Value::Null,
-            raw_updates: Vec::new(),
-            theme: "neutral",
-        };
-        s.refresh().await;
-        s
-    }
-    async fn refresh(&mut self) {
-        let start = now();
-        if !self.raw_updates.is_empty() {
-            self.ctx.logger.info("Refreshing data");
-        }
-        let updates = sort_update_vec(&get_updates(&None, true, &self.ctx).await);
-        self.ctx.logger.info(format!(
-            "✨ Checked {} images in {}ms",
-            updates.len(),
-            elapsed(start)
-        ));
-        self.raw_updates = updates;
-        let template = liquid::ParserBuilder::with_stdlib()
-            .build()
-            .unwrap()
-            .parse(HTML)
-            .unwrap();
-        self.simple_json = to_simple_json(&self.raw_updates);
-        self.full_json = to_full_json(&self.raw_updates);
-        let last_updated = Local::now();
-        self.simple_json["last_updated"] = last_updated
-            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
-            .to_string()
-            .into();
-        self.full_json["last_updated"] = self.simple_json["last_updated"].clone();
-        self.theme = match &self.ctx.config.theme {
+    fn new(ctx: &Context) -> Self {
+        let theme = match &ctx.config.theme {
             Theme::Default => "neutral",
             Theme::Blue => "gray",
         };
-        let mut metrics = self.simple_json["metrics"]
-            .as_object()
+        // Pre-render the template with empty data so the fallback HTML is valid
+        // (prevents Liquid tag leaks if the lock can't be acquired during a refresh)
+        let fallback_template = liquid::ParserBuilder::with_stdlib()
+            .build()
             .unwrap()
-            .iter()
-            .map(|(key, value)| liquid::object!({ "name": key, "value": value }))
-            .collect::<Vec<_>>();
-        metrics.sort_unstable_by(|a, b| {
-            SORT_ORDER
-                .iter()
-                .position(|i| i == &a["name"].to_kstr().as_str())
-                .unwrap()
-                .cmp(
-                    &SORT_ORDER
-                        .iter()
-                        .position(|i| i == &b["name"].to_kstr().as_str())
-                        .unwrap(),
-                )
-        });
-        let mut servers: FxHashMap<&str, Vec<Object>> = FxHashMap::default();
-        self.raw_updates.iter().for_each(|update| {
-            let key = update.server.as_deref().unwrap_or("");
-            match servers.get_mut(&key) {
-                Some(server) => server.push(
-                    object!({"name": update.reference, "status": update.get_status().to_string()}),
-                ),
-                None => {
-                    let _ = servers.insert(key, vec![object!({"name": update.reference, "status": update.get_status().to_string()})]);
-                }
-            }
-        });
-        let globals = object!({
-            "metrics": metrics,
-            "servers": servers,
-            "server_ids": servers.into_keys().collect::<Vec<&str>>(),
-            "last_updated": last_updated.format("%Y-%m-%d %H:%M:%S").to_string(),
-            "theme": &self.theme
-        });
-        self.template = template.render(&globals).unwrap();
+            .parse(HTML)
+            .unwrap()
+            .render(&object!({
+                "metrics": [],
+                "servers": liquid::object!({}),
+                "server_ids": Vec::<&str>::new(),
+                "last_updated": "",
+                "theme": theme
+            }))
+            .unwrap();
+        Self {
+            ctx: ctx.clone(),
+            template: fallback_template,
+            simple_json: Value::Null,
+            full_json: Value::Null,
+            raw_updates: Vec::new(),
+            theme,
+        }
     }
+}
+
+/// Refresh all data without blocking the API. Fetches everything outside the lock,
+/// then briefly locks to swap in the new data.
+async fn background_refresh(data: Arc<Mutex<ServerData>>) {
+    let (ctx, is_refresh) = {
+        let d = data.lock().await;
+        (d.ctx.clone(), !d.raw_updates.is_empty())
+    };
+    let start = now();
+    if is_refresh {
+        ctx.logger.info("Refreshing data");
+    }
+    let updates = sort_update_vec(&get_updates(&None, true, &ctx).await);
+    ctx.logger.info(format!(
+        "✨ Checked {} images in {}ms",
+        updates.len(),
+        elapsed(start)
+    ));
+    let mut d = data.lock().await;
+    d.raw_updates = updates;
+    let template = liquid::ParserBuilder::with_stdlib()
+        .build()
+        .unwrap()
+        .parse(HTML)
+        .unwrap();
+    d.simple_json = to_simple_json(&d.raw_updates);
+    d.full_json = to_full_json(&d.raw_updates);
+    let last_updated = Local::now();
+    d.simple_json["last_updated"] = last_updated
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+        .to_string()
+        .into();
+    d.full_json["last_updated"] = d.simple_json["last_updated"].clone();
+    d.theme = match &d.ctx.config.theme {
+        Theme::Default => "neutral",
+        Theme::Blue => "gray",
+    };
+    let mut metrics = d.simple_json["metrics"]
+        .as_object()
+        .unwrap()
+        .iter()
+        .map(|(key, value)| liquid::object!({ "name": key, "value": value }))
+        .collect::<Vec<_>>();
+    metrics.sort_unstable_by(|a, b| {
+        SORT_ORDER
+            .iter()
+            .position(|i| i == &a["name"].to_kstr().as_str())
+            .unwrap()
+            .cmp(
+                &SORT_ORDER
+                    .iter()
+                    .position(|i| i == &b["name"].to_kstr().as_str())
+                    .unwrap(),
+            )
+    });
+    let mut servers: FxHashMap<&str, Vec<Object>> = FxHashMap::default();
+    d.raw_updates.iter().for_each(|update| {
+        let key = update.server.as_deref().unwrap_or("");
+        match servers.get_mut(&key) {
+            Some(server) => server.push(
+                object!({"name": update.reference, "status": update.get_status().to_string()}),
+            ),
+            None => {
+                let _ = servers.insert(key, vec![object!({"name": update.reference, "status": update.get_status().to_string()})]);
+            }
+        }
+    });
+    let globals = object!({
+        "metrics": metrics,
+        "servers": servers,
+        "server_ids": servers.into_keys().collect::<Vec<&str>>(),
+        "last_updated": last_updated.format("%Y-%m-%d %H:%M:%S").to_string(),
+        "theme": &d.theme
+    });
+    d.template = template.render(&globals).unwrap();
 }
 
 async fn logger<S, C, B>(next: &S, ctx: WebContext<'_, C, B>) -> Result<WebResponse, Error<C>>


### PR DESCRIPTION
## Motivation

I run Cup with several images from the immich project, including `ghcr.io/immich-app/immich-machine-learning:v2` which has 1000+ tags on ghcr.io. I noticed that startup was slow and the API would become completely unresponsive during refreshes, Homepage dashboard widgets would time out waiting for a response.

I started debugging and ended up going down a bit of a rabbit hole with a progressive loading prototype, but I wanted to bring it back to a focused set of changes that could benefit the community.

## Changes

### Request more tags per page from registries

The `/v2/{repo}/tags/list` endpoint was being called without specifying a page size, so Cup used the registry's default (often very small). For repos with thousands of tags, this meant hundreds of HTTP round trips just to list all tags. Adding `?n=10000` asks the registry to return up to 10,000 tags per page. Registries that honour this parameter will respond with fewer pages. Those that don't will simply ignore it and continue with their own default.

### Non-blocking background refresh

Previously, the server held a lock on its shared data for the entire duration of a refresh — several seconds of network requests. Any API call during that time had to wait for the lock, making the API unresponsive.

The refresh now works differently:

1. Briefly lock to read the configuration, then release
2. Do all the slow network fetching with no lock held (the API continues serving the previous data)
3. Briefly lock again to swap in the new results

This applies to both the cron-scheduled refresh and the manual `/api/v3/refresh` endpoint (which now returns immediately and runs the refresh in the background). The initial startup still waits for the first check to complete before serving.

### Extracting reusable update-fetching functions

The update-checking logic has been split into independently callable pieces (`get_local_updates()`, `get_single_server_updates()`), which is what makes the non-blocking refresh possible. This also opens the door for future improvements like progressive loading at startup.

## Testing

I've been running these changes in my homelab for about a week across 4 Cup instances (one main instance aggregating the other three), monitoring 72 images in total.

The image that originally led me to investigate was `ghcr.io/immich-app/immich-machine-learning:v2`. For reference, ghcr.io honours the `n` parameter but caps it at 1000 tags per page, so even though we request 10,000, we get 1000 instead of the default 100. That's still a 10x reduction in round trips, and registries with a higher or no cap would benefit even more. That said, `immich-machine-learning` has so many tags that I still have it excluded from Cup, the improvement helps but checking it is still slow enough to be disruptive. `ghcr.io/immich-app/immich-server:v2` is monitored without issues.

No problems observed during the week: refreshes complete in the background, the API stays responsive throughout, and Homepage dashboard widgets no longer time out.
