### PR TITLE
Fix edgecase docker.io image reported as unused

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -125,8 +125,10 @@ pub async fn get_updates(
 
     // Complete in_use field
     images.iter_mut().for_each(|image| {
-        if in_use_images.contains(&image.reference) {
-            image.in_use = true
+        if let Some(id) = &image.id {
+            if in_use_images.contains(id) {
+                image.in_use = true
+            }
         }
     });
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -120,14 +120,8 @@ pub async fn get_in_use_images(ctx: &Context) -> Vec<String> {
 
     containers
         .iter()
-        .filter_map(|container| match &container.image {
-            Some(image) => Some({
-                if image.contains(":") {
-                    image.clone()
-                } else {
-                    format!("{image}:latest")
-                }
-            }),
+        .filter_map(|container| match &container.image_id {
+            Some(image_id) => Some(image_id.clone()),
             None => None,
         })
         .collect()

--- a/src/structs/image.rs
+++ b/src/structs/image.rs
@@ -33,6 +33,7 @@ pub struct VersionInfo {
 #[derive(Clone, PartialEq, Default)]
 #[cfg_attr(test, derive(Debug))]
 pub struct Image {
+    pub id: Option<String>,
     pub reference: String,
     pub parts: Parts,
     pub url: Option<String>,
@@ -71,6 +72,7 @@ impl Image {
                 )
                 .collect();
             Some(Self {
+                id: image.image_id(),
                 reference,
                 parts: Parts {
                     registry,

--- a/src/structs/inspectdata.rs
+++ b/src/structs/inspectdata.rs
@@ -4,6 +4,7 @@ pub trait InspectData {
     fn tags(&self) -> Option<Vec<String>>;
     fn digests(&self) -> Option<Vec<String>>;
     fn url(&self) -> Option<String>;
+    fn image_id(&self) -> Option<String>;
 }
 
 impl InspectData for ImageInspect {
@@ -24,6 +25,10 @@ impl InspectData for ImageInspect {
             None => None,
         }
     }
+
+    fn image_id(&self) -> Option<String> {
+        self.id.clone()
+    }
 }
 
 impl InspectData for ImageSummary {
@@ -37,6 +42,10 @@ impl InspectData for ImageSummary {
 
     fn url(&self) -> Option<String> {
         self.labels.get("org.opencontainers.image.url").cloned()
+    }
+
+    fn image_id(&self) -> Option<String> {
+        Some(self.id.clone())
     }
 }
 
@@ -57,6 +66,10 @@ impl InspectData for &String {
     }
 
     fn url(&self) -> Option<String> {
+        None
+    }
+
+    fn image_id(&self) -> Option<String> {
         None
     }
 }


### PR DESCRIPTION
Currently, to check if an image is used or not, the reference is checked.

This can cause edge-case issues with docker.io being masked by Docker.

To reproduce you can make this:
```
docker run docker.io/hello-world:latest
```
(Note the use of explicit `docker.io`)

The container will have `docker.io/hello-world:latest` as image, and the image reference will be `hello-world:latest`. 

This cause the image to be reported as unused because it will test `hello-world:latest` against `docker.io/hello-world:latest` which don't match.

To address this issue, I change the comparison to use image id instead. It's my first time with rust btw.

(nb: I was not able to test for swarm so the image id is set as None for now)