### PR TITLE
Don't exit the process on unexpected registry responses

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -4,7 +4,7 @@ use reqwest::Response;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 
-use crate::{error, Context};
+use crate::Context;
 
 pub enum RequestMethod {
     GET,
@@ -83,18 +83,20 @@ impl Client {
                 } else if status.as_u16() <= 400 {
                     Ok(response)
                 } else {
-                    match method {
-                        RequestMethod::GET => error!(
+                    let message = match method {
+                        RequestMethod::GET => format!(
                             "{} {}: Unexpected error: {}",
                             method,
                             url,
                             response.text().await.unwrap()
                         ),
-                        RequestMethod::HEAD => error!(
+                        RequestMethod::HEAD => format!(
                             "{} {}: Unexpected error: Recieved status code {}",
                             method, url, status
                         ),
-                    }
+                    };
+                    self.ctx.logger.warn(&message);
+                    Err(message)
                 }
             }
             Err(error) => {
@@ -111,12 +113,14 @@ impl Client {
                     self.ctx.logger.warn(&message);
                     Err(message)
                 } else {
-                    error!(
+                    let message = format!(
                         "{} {}: Unexpected error: {}",
                         method,
                         url,
                         error.to_string()
-                    )
+                    );
+                    self.ctx.logger.warn(&message);
+                    Err(message)
                 }
             }
         }


### PR DESCRIPTION
## Problem

When a registry returns an **unexpected** HTTP status (e.g. `429 Too Many Requests`) for a manifest `HEAD`/`GET`, `Client::request` calls the `error!` macro, which runs `std::process::exit(1)` and kills the whole process.

This is inconsistent with every other error branch in the same function — `404`, `401`, `403`, `502`, connect failures, timeouts, and retry-exhaustion all `logger.warn(...)` and return `Err(message)` (non-fatal). Only the "unexpected status" and "unexpected connection error" branches are fatal.

It hurts most in `serve` mode: the initial refresh runs **before** the HTTP server binds (`ServerData::new` → `refresh` → `get_updates`), so a single registry returning `429` during the startup scan makes the process exit before it ever serves. Under a container restart policy (`restart: unless-stopped`) it then **crash-loops**, and because each restart re-issues the same authenticated request, it keeps the rate-limit window alive — turning a transient blip into a sustained, self-inflicted outage. The web UI stays completely down.

Observed in the wild with `docker.n8n.io` (n8n's registry) returning `429` on `HEAD .../n8nio/n8n/manifests/<tag>`:

```
ERROR HEAD https://docker.n8n.io/v2/n8nio/n8n/manifests/2.29.5: Unexpected error: Recieved status code 429 Too Many Requests
 INFO Starting server, please wait...
ERROR HEAD ...429 Too Many Requests
 INFO Starting server, please wait...
... (dozens of restarts)
```

## Change

Make the two fatal branches behave like the others: `warn` + `Err(message)` instead of `error!`. No downstream change needed — callers already handle `Err` gracefully (`get_latest_digest` returns `Image { error: Some(..), .. }` and the check continues), so the affected image simply shows as errored for that cycle and recovers on the next refresh, while `cup` stays up and keeps checking every other image.

Only `src/http.rs` is touched; `error!` is no longer used there so it's dropped from the import. Compiles clean (`cargo check`) and `cargo fmt --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)