### PR TITLE
chore: remove link to notice from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/sergi0g/cup)
 [![Discord](https://img.shields.io/discord/1337705080518086658)](https://discord.gg/jmh5ctzwNG)
 
-> [!IMPORTANT]
-> There have been some important changes regarding Cup's development. Read more [here](./NOTICE.md).
-
 Cup is the easiest way to check for container image updates.
 
 ![Cup web in dark mode](screenshots/web_dark.png)


### PR DESCRIPTION
I noticed that `NOTICE.md` was removed in c38429ce7d72c86e0c677b32c452ae8addd470f7 without removing the link from the readme.

---

I hope such PRs are OK without creating an issue first. Thanks for the great app and nice to see that you may be diving back into further development!