### PR TITLE
fix: add HTTP timeouts so an unresponsive peer can't hang Cup permanently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.7", features = ["derive"] }
 indicatif = { version = "0.17.8", optional = true }
-tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread", "time", "net"] }
 xitca-web = { version = "0.6.2", optional = true }
 liquid = { version = "0.26.6", optional = true }
 bollard = "0.18.1"

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use futures::future::join_all;
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -14,63 +16,118 @@ use crate::{
     Context,
 };
 
+/// Upper bound on how long we'll wait for a single remote Cup instance.
+///
+/// Deliberately generous, because `/api/v3/refresh` makes the remote run its own full
+/// registry check before it answers. But it must exist: `serve()` does not bind its port
+/// until the first check finishes, so a single unresponsive peer would otherwise stop Cup
+/// from ever starting.
+const REMOTE_SERVER_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Fetches image data from a single remote Cup instance.
+async fn get_server_updates(
+    ctx: &Context,
+    client: &Client,
+    name: &str,
+    url: &str,
+    refresh: bool,
+) -> Vec<Update> {
+    let base_url = if url.starts_with("http://") || url.starts_with("https://") {
+        format!("{}/api/v3/", url.trim_end_matches('/'))
+    } else {
+        format!("https://{}/api/v3/", url.trim_end_matches('/'))
+    };
+    let json_url = base_url.clone() + "json";
+    if refresh {
+        let refresh_url = base_url + "refresh";
+        match client.get(&refresh_url, &[], false).await {
+            Ok(response) => {
+                if response.status() != 200 {
+                    ctx.logger.warn(format!("GET {}: Failed to refresh server. Server returned invalid response code: {}", refresh_url, response.status()));
+                    return Vec::new();
+                }
+            }
+            Err(e) => {
+                ctx.logger.warn(format!(
+                    "GET {}: Failed to refresh server. {}",
+                    refresh_url, e
+                ));
+                return Vec::new();
+            }
+        }
+    }
+    match client.get(&json_url, &[], false).await {
+        Ok(response) => {
+            if response.status() != 200 {
+                ctx.logger.warn(format!("GET {}: Failed to fetch updates from server. Server returned invalid response code: {}", json_url, response.status()));
+                return Vec::new();
+            }
+            let json = parse_json(&get_response_body(response).await);
+            ctx.logger
+                .debug(format!("JSON response for {}: {}", name, json));
+            if let Some(updates) = json["images"].as_array() {
+                let mut server_updates: Vec<Update> = updates
+                    .iter()
+                    .filter_map(|img| serde_json::from_value(img.clone()).ok())
+                    .collect();
+                // Add server origin to each image
+                for update in &mut server_updates {
+                    update.server = Some(name.to_string());
+                    update.status = update.get_status();
+                }
+                ctx.logger
+                    .debug(format!("Updates for {}: {:#?}", name, server_updates));
+                return server_updates;
+            }
+
+            Vec::new()
+        }
+        Err(e) => {
+            ctx.logger.warn(format!(
+                "GET {}: Failed to fetch updates from server. {}",
+                json_url, e
+            ));
+            Vec::new()
+        }
+    }
+}
+
 /// Fetches image data from other Cup instances
 async fn get_remote_updates(ctx: &Context, client: &Client, refresh: bool) -> Vec<Update> {
+    get_remote_updates_bounded(ctx, client, refresh, REMOTE_SERVER_TIMEOUT).await
+}
+
+/// The body of [`get_remote_updates`], with the per-server timeout injected so tests don't
+/// have to wait out the production value.
+async fn get_remote_updates_bounded(
+    ctx: &Context,
+    client: &Client,
+    refresh: bool,
+    per_server_timeout: Duration,
+) -> Vec<Update> {
     let mut remote_images = Vec::new();
 
-    let handles: Vec<_> = ctx.config.servers
+    let handles: Vec<_> = ctx
+        .config
+        .servers
         .iter()
         .map(|(name, url)| async move {
-            let base_url = if url.starts_with("http://") || url.starts_with("https://") {
-                format!("{}/api/v3/", url.trim_end_matches('/'))
-            } else {
-                format!("https://{}/api/v3/", url.trim_end_matches('/'))
-            };
-            let json_url = base_url.clone() + "json";
-            if refresh {
-                let refresh_url = base_url + "refresh";
-                match client.get(&refresh_url, &[], false).await {
-                    Ok(response) => {
-                        if response.status() != 200 {
-                            ctx.logger.warn(format!("GET {}: Failed to refresh server. Server returned invalid response code: {}", refresh_url, response.status()));
-                            return Vec::new();
-                        }
-                    },
-                    Err(e) => {
-                        ctx.logger.warn(format!("GET {}: Failed to refresh server. {}", refresh_url, e));
-                        return Vec::new();
-                    },
-                }
-
-            }
-            match client.get(&json_url, &[], false).await {
-                Ok(response) => {
-                    if response.status() != 200 {
-                        ctx.logger.warn(format!("GET {}: Failed to fetch updates from server. Server returned invalid response code: {}", json_url, response.status()));
-                        return Vec::new();
-                    }
-                    let json = parse_json(&get_response_body(response).await);
-                    ctx.logger.debug(format!("JSON response for {}: {}", name, json));
-                    if let Some(updates) = json["images"].as_array() {
-                        let mut server_updates: Vec<Update> = updates
-                            .iter()
-                            .filter_map(|img| serde_json::from_value(img.clone()).ok())
-                            .collect();
-                        // Add server origin to each image
-                        for update in &mut server_updates {
-                            update.server = Some(name.clone());
-                            update.status = update.get_status();
-                        }
-                        ctx.logger.debug(format!("Updates for {}: {:#?}", name, server_updates));
-                        return server_updates;
-                    }
-
+            match tokio::time::timeout(
+                per_server_timeout,
+                get_server_updates(ctx, client, name, url, refresh),
+            )
+            .await
+            {
+                Ok(updates) => updates,
+                Err(_) => {
+                    ctx.logger.warn(format!(
+                        "Timed out after {}s waiting for server {} ({}). Skipping it.",
+                        per_server_timeout.as_secs(),
+                        name,
+                        url
+                    ));
                     Vec::new()
                 }
-                Err(e) => {
-                    ctx.logger.warn(format!("GET {}: Failed to fetch updates from server. {}", json_url, e));
-                    Vec::new()
-                },
             }
         })
         .collect();
@@ -229,4 +286,54 @@ pub async fn get_updates(
     let mut updates: Vec<Update> = images.iter().map(|image| image.to_update()).collect();
     updates.extend_from_slice(&remote_updates);
     updates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::logging::Logger;
+    use std::time::Instant;
+
+    /// A remote server that completes the TCP handshake and then never sends a byte used to
+    /// block `get_remote_updates` forever, because the HTTP client had no timeout. `serve()`
+    /// runs this check *before* binding its port, so one such peer kept Cup from starting.
+    #[tokio::test]
+    async fn unresponsive_remote_server_is_skipped_not_awaited_forever() {
+        // A listener that accepts connections and then holds them open in silence.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut accepted = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                accepted.push(stream);
+            }
+        });
+
+        let mut config = Config::new();
+        config
+            .servers
+            .insert("stalled".to_string(), format!("http://{}", addr));
+        let ctx = Context {
+            config,
+            logger: Logger::new(false, false),
+        };
+        let client = Client::new(&ctx);
+
+        let per_server_timeout = Duration::from_secs(1);
+        let start = Instant::now();
+        let updates = get_remote_updates_bounded(&ctx, &client, true, per_server_timeout).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            updates.is_empty(),
+            "a silent server should contribute no updates"
+        );
+        assert!(
+            elapsed < per_server_timeout * 5,
+            "expected the stalled server to be abandoned near {:?}, but waited {:?}",
+            per_server_timeout,
+            elapsed
+        );
+    }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::time::Duration;
 
 use reqwest::Response;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
@@ -26,10 +27,32 @@ pub struct Client {
     ctx: Context,
 }
 
+/// How long to wait for a TCP connection to be established.
+///
+/// Without this, a host that is down or silently dropping packets sits in the kernel's SYN
+/// retry loop for over two minutes before `reqwest` reports a failure — multiplied by the
+/// retry middleware below.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Upper bound on a single request, from start to response body.
+///
+/// `reqwest` applies **no** timeout by default, so a peer that completes the handshake and
+/// then never answers blocks the caller forever. Generous enough for a remote Cup instance
+/// running its own registry check in response to `/api/v3/refresh`.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
 impl Client {
     pub fn new(ctx: &Context) -> Self {
+        let inner = match reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+        {
+            Ok(client) => client,
+            Err(e) => error!("Failed to build the HTTP client: {}", e),
+        };
         Self {
-            inner: ClientBuilder::new(reqwest::Client::new())
+            inner: ClientBuilder::new(inner)
                 .with(RetryTransientMiddleware::new_with_policy(
                     ExponentialBackoff::builder().build_with_max_retries(3),
                 ))


### PR DESCRIPTION
## The problem

`Client::new` builds a bare `reqwest::Client::new()`, which applies **no** request or connect timeout by default. Any host that completes the TCP handshake and then stops responding blocks the caller forever — with no error and no log line, because nothing ever fails.

I hit two distinct failure modes from this in a 3-instance deployment (one server aggregating two agents).

### 1. An agent wedges itself permanently

If a registry accepts a connection and never answers, the agent hangs inside `refresh()`. The `/api/v3/refresh` handler holds the `Mutex<ServerData>` for the entire call:

```rust
async fn refresh(data: StateRef<'_, Arc<Mutex<ServerData>>>) -> WebResponse {
    data.lock().await.refresh().await;
```

Every other handler locks the same mutex — `_static`, `api_simple`, `api_full`. So once that happens the agent stops answering **everything**, including the web UI, while still accepting TCP connections. It never recovers without a restart.

The symptom is quiet enough to be hard to spot: the log just ends on `INFO Refreshing data` with no `✨ Checked N images` after it, and `curl` to any endpoint returns nothing at all.

```
 INFO ✨ Checked 7 images in 1119ms
 HTTP GET /api/v3/refresh 200 in 1129ms
 INFO Refreshing data              <- started, never finished

$ curl -m 10 -o /dev/null -w '%{http_code} in %{time_total}s\n' http://<agent>/api/v3/json
000 in 10.002385s
```

That same endpoint answered in 0.0017s minutes earlier.

### 2. The aggregating instance then never starts

`get_remote_updates` has no bound of its own, and `serve()` doesn't bind its port until the first check completes:

```rust
ctx.logger.info("Starting server, please wait...");
let data = ServerData::new(ctx).await;   // <- blocks here forever
...
ctx.logger.info("Ready to start!");
...bind(format!("0.0.0.0:{}", port))
```

So one wedged agent stopped the aggregating instance from ever starting. It sat at `Starting server, please wait...` with no further output — no warning, no error, nothing to indicate which peer was responsible.

## The fix

- **`http.rs`** — a 10s connect timeout and a 60s request timeout. The connect timeout also avoids the kernel's ~2 minute SYN retry loop for a host that's down, multiplied by the retry middleware. This has the side effect of making the existing `error.is_timeout()` arm reachable; it was dead code before, since nothing could ever time out.

- **`check.rs`** — extract the per-server body into `get_server_updates` and wrap each server in a `tokio::time::timeout`, so the fan-out stays bounded regardless of how the retry middleware behaves. A server that exceeds the budget is warned about **by name** and skipped:

  ```
  WARN Timed out after 60s waiting for server vm-prod-03 (http://192.168.5.233:8765). Skipping it.
  ```

  That line alone would have made the original diagnosis a minute's work instead of an afternoon's.

- **`Cargo.toml`** — enable tokio's `time` and `net` features explicitly rather than relying on them arriving transitively via reqwest.

## Test

Included: a listener that accepts connections and then holds them in silence — the exact failure — asserting the fan-out returns rather than hanging. The timeout is injected via `get_remote_updates_bounded` so the test runs in ~1s instead of waiting out the production value.

## Notes / open questions

- **`REMOTE_SERVER_TIMEOUT` is 60s**, which I picked to be safe for large remotes, since `/api/v3/refresh` makes the remote run its own full check before answering. Healthy agents in my setup answer in ~1.2s. Happy to make it configurable via `cup.json` instead of a constant if you'd prefer — I kept this PR minimal on purpose.
- There's a **related but separate bug** I've also fixed locally: a registry returning 429 falls through to the catch-all `error!` arm, which calls `std::process::exit(1)`. With `restart: unless-stopped` a transient rate limit becomes a crash loop. Happy to open that as its own PR if useful.