### PR TITLE
fix: treat a registry 429 as non-fatal instead of exiting the process

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -80,6 +80,13 @@ impl Client {
                     );
                     self.ctx.logger.warn(&message);
                     Err(message)
+                } else if status == 429 {
+                    let message = format!(
+                        "{} {}: Rate limited by the registry (returned status code 429). Skipping this check.",
+                        method, url
+                    );
+                    self.ctx.logger.warn(&message);
+                    Err(message)
                 } else if status.as_u16() <= 400 {
                     Ok(response)
                 } else {


### PR DESCRIPTION
## The problem

A request returning `429 Too Many Requests` isn't handled explicitly, so it falls through to the catch-all arm in `Client::request`:

```rust
} else if status.as_u16() <= 400 {
    Ok(response)
} else {
    match method {
        RequestMethod::GET => error!(...),
        RequestMethod::HEAD => error!(...),
    }
}
```

and `error!` calls `std::process::exit(1)`.

Combined with the `restart: unless-stopped` that the docs recommend, a transient registry rate limit becomes a container crash loop: Cup exits partway through its check, the container restarts, the check runs again, the registry is still rate limiting, and it exits again. It recovers only when the limit window rolls over.

Docker Hub's anonymous pull limit makes this easy to hit. Anyone monitoring a few dozen Hub images from one IP can run into it, and a vanity domain in front of Hub (`docker.n8n.io` in my case) counts against the same bucket.

The retry middleware doesn't save you here — `reqwest-retry` classifies 429 as transient, so by the time this arm is reached the retries are already exhausted.

## The fix

Handle 429 exactly the way 502/503 is already handled a few lines above — warn, skip that check, keep running:

```
WARN HEAD https://docker.n8n.io/v2/n8nio/n8n/manifests/latest: Rate limited by the registry (returned status code 429). Skipping this check.
```

One rate-limited registry then costs the freshness of the images in that registry, rather than the whole process. That image shows as unknown until the next successful check, which seems like the right trade for a monitoring tool.

## Notes

- No test. The pre-fix behavior is `std::process::exit(1)`, which can't be observed from inside the test binary, and asserting the post-fix `Err` requires standing up a listener and waiting out ~13s of retry backoff before the branch is even reached. That felt like poor value against the repo's existing test style for a 7-line change mirroring the adjacent 502/503 arm — happy to add one if you'd like it.
- Independent of #175. Both branch from the same commit and touch different parts of `http.rs` (`Client::new` vs. the status chain), so they merge cleanly in either order.