### PR TITLE
fix: don't exit the process when a registry's token endpoint fails

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -181,6 +181,9 @@ pub async fn get_updates(
 
     // Retrieve an authentication token (if required) for each registry.
     let mut tokens: FxHashMap<&str, Option<String>> = FxHashMap::default();
+    // Registries whose token could not be fetched (e.g. the token endpoint returned
+    // 403/429). Their images are surfaced as errored rather than crashing the run.
+    let mut token_errors: FxHashMap<&str, String> = FxHashMap::default();
     for registry in registries.clone() {
         let credentials = if let Some(registry_config) = ctx.config.registries.get(registry) {
             &registry_config.authentication
@@ -189,14 +192,21 @@ pub async fn get_updates(
         };
         match check_auth(registry, ctx, &client).await {
             Some(auth_url) => {
-                let token = get_token(
+                match get_token(
                     image_map.get(registry).unwrap(),
                     &auth_url,
                     credentials,
                     &client,
                 )
-                .await;
-                tokens.insert(registry, Some(token));
+                .await
+                {
+                    Ok(token) => {
+                        tokens.insert(registry, Some(token));
+                    }
+                    Err(error) => {
+                        token_errors.insert(registry, error);
+                    }
+                }
             }
             None => {
                 tokens.insert(registry, None);
@@ -207,6 +217,9 @@ pub async fn get_updates(
     ctx.logger.debug(format!("Tokens: {:?}", tokens));
 
     let mut handles = Vec::with_capacity(images.len());
+    // Images belonging to a registry whose token fetch failed. They're surfaced with
+    // the token error instead of being checked (which would only fail again).
+    let mut errored_images: Vec<Image> = Vec::new();
 
     // Loop through images check for updates
     for image in &images {
@@ -218,6 +231,13 @@ pub async fn get_updates(
                 .iter()
                 .any(|item| image.reference.starts_with(item));
         if !is_ignored {
+            if let Some(error) = token_errors.get(image.parts.registry.as_str()) {
+                errored_images.push(Image {
+                    error: Some(error.clone()),
+                    ..image.clone()
+                });
+                continue;
+            }
             let excluded_tags = get_excluded_tags(image, ctx);
             let token = tokens.get(image.parts.registry.as_str()).unwrap();
             let future = image.check(token.as_deref(), ctx, &client, excluded_tags);
@@ -225,7 +245,8 @@ pub async fn get_updates(
         }
     }
     // Await all the futures
-    let images = join_all(handles).await;
+    let mut images = join_all(handles).await;
+    images.extend(errored_images);
     let mut updates: Vec<Update> = images.iter().map(|image| image.to_update()).collect();
     updates.extend_from_slice(&remote_updates);
     updates

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -100,7 +100,7 @@ pub async fn get_token(
     auth_url: &str,
     credentials: &Option<String>,
     client: &Client,
-) -> String {
+) -> Result<String, String> {
     let mut url = auth_url.to_owned();
     for image in images {
         url = format!("{}&scope=repository:{}:pull", url, image.parts.repository);
@@ -108,12 +108,19 @@ pub async fn get_token(
     let authorization = credentials.as_ref().map(|creds| format!("Basic {}", creds));
     let headers = [("Authorization", authorization.as_deref())];
 
-    let response = client.get(&url, &headers, false).await;
-    let response_json = match response {
-        Ok(response) => parse_json(&get_response_body(response).await),
-        Err(_) => error!("GET {}: Request failed!", url),
-    };
-    response_json["token"].as_str().unwrap().to_string()
+    // A failed token request (e.g. the registry returns 403/429 for the token
+    // endpoint) must not be fatal. Exiting here takes down the whole server over a
+    // single unreachable registry, and under `restart: unless-stopped` that becomes a
+    // crash loop. Propagate the error so the caller can skip this registry's images.
+    let response = client.get(&url, &headers, false).await?;
+    let response_json = parse_json(&get_response_body(response).await);
+    match response_json["token"].as_str() {
+        Some(token) => Ok(token.to_string()),
+        None => Err(format!(
+            "GET {}: Registry did not include a token in its response.",
+            url
+        )),
+    }
 }
 
 pub async fn get_latest_tag(


### PR DESCRIPTION
## The problem

`get_token` returns `String`, so it has no way to report failure:

```rust
let response = client.get(&url, &headers, false).await;
let response_json = match response {
    Ok(response) => parse_json(&get_response_body(response).await),
    Err(_) => error!("GET {}: Request failed!", url),
};
response_json["token"].as_str().unwrap().to_string()
```

`error!` calls `std::process::exit(1)`. So a token request returning 403, 429 or 5xx doesn't skip that registry — it takes down the whole process. With the `restart: unless-stopped` the docs recommend, that becomes a crash loop: Cup exits during the token phase, the container restarts, it tries the same registry, and it exits again.

There's also a latent panic on the last line: `response_json["token"].as_str()` is unwrapped, so a 200 response without a `token` field aborts the process.

## How easily this triggers

`gcr.io` returns 403 for anonymous token requests. One `gcr.io/...` image among dozens is enough to kill an otherwise healthy instance:

```
WARN GET https://gcr.io/v2/token?&service=gcr.io&scope=repository:zenika-hub/alpine-chrome:pull: Forbidden!
```

That's from my own deployment — 134 images across three hosts, one of which happens to be `gcr.io/zenika-hub/alpine-chrome:123`.

## The fix

- **`registry.rs`** — `get_token` returns `Result<String, String>` and propagates the client error instead of exiting. A token-less response body becomes an `Err` rather than an `unwrap()` panic.

- **`check.rs`** — `get_updates` records the failure per registry and surfaces it on that registry's images, which then report `Status::Unknown(error)`. That's the same treatment `Image::error` already gives a failed digest check, so it needs no new UI work — the affected images show as unknown with the reason attached, and everything else is checked normally.

An unreachable registry now costs the freshness of that registry's images, with the reason visible, instead of costing the process.

## Relationship to the other PRs

Same class of bug as #176 (429 handling) but on a different code path — that one is the HEAD/manifest request, this one is the token request. All three of my open PRs are independent and I've verified this branch merges cleanly with both #175 and #176 in either order.

Together they close out the pattern where a transient or partial registry problem kills a running instance rather than degrading one image's result.

## Notes

- No new clippy warnings — I diffed `cargo clippy --all-targets` against a clean `main` and the four existing warnings (`config.rs`, `docker.rs`, `utils/request.rs`) are unchanged; neither touched file appears.
- No test, for the same reason as #176: the pre-fix behavior is `std::process::exit(1)`, which can't be observed from inside the test binary. Happy to add coverage for the `Result` path if you'd like it.